### PR TITLE
Add `xftCharExists` binding and add support for multiple fonts

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -74,11 +74,6 @@ jobs:
             compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,19 @@
 
 ## unknown
 
+  * Dropped support for GHC 7.10.
+
+  * Added `xftDrawStringFallback`, which works like `xftDrawString` but
+    supports font fallback.
+
+  * Added `xftTextAccumExtents`, which works like `xftTextExtents` but
+    possibly uses different fonts for different parts of the string and
+    returns the accumulative extents.
+
+  * Added the functions `xftfont_max_ascent`, `xftfont_min_descent`, and
+    `xftfont_max_height` to gain information about a non-empty list of
+    `XftFont`s.
+
 ## 0.3.3 (2021-05-09)
 
   * Fixed flipped green/blue values in XRenderColor.

--- a/X11-xft.cabal
+++ b/X11-xft.cabal
@@ -12,7 +12,7 @@ description:   A Haskell bindings to the X Font library. With it, Haskell X11
                fonts with anti-aliasing and subpixel rendering. The bindings
                also provide minimal bindings to Xrender parts.
 build-type:    Simple
-tested-with:   GHC == 7.10.3 || == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.4 || == 9.0.1 || == 9.2.1
+tested-with:   GHC == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.4 || == 9.0.1 || == 9.2.1
 extra-source-files: CHANGES.md
                     README.md
 


### PR DESCRIPTION
Mostly move implementation from xmobar's [MinXft](https://github.com/jaor/xmobar/blob/master/src/Xmobar/X11/MinXft.hsc). Now  we are able to remove MinXft from https://github.com/xmonad/xmonad-contrib/pull/646.

Functions with prime is an alternative for working with multiple fonts