### PR TITLE
CI maintenance (haskell-ci bump, GHA deprecations, GHC 9.4)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -35,9 +35,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.4.2
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20221009
 #
-# REGENDATA ("0.14.3",["github","cabal.project"])
+# REGENDATA ("0.15.20221009",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -26,7 +26,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -84,10 +84,10 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
             apt-get update
             apt-get install -y libx11-dev libxext-dev libxft-dev libxinerama-dev libxrandr-dev libxss-dev
           else
@@ -95,9 +95,9 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME" libx11-dev libxext-dev libxft-dev libxinerama-dev libxrandr-dev libxss-dev
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}

--- a/.github/workflows/packdeps.yml
+++ b/.github/workflows/packdeps.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Haskell
         uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -59,7 +59,7 @@ jobs:
         # date is prefixed with an epoch number to let us manually refresh the
         # cache when needed. This is a workaround for https://github.com/actions/cache/issues/2
         run: |
-          echo "::set-output name=date::1-$(date +%Y-%m)"
+          date +date=1-%Y-%m >> $GITHUB_OUTPUT
 
       - name: Cache Haskell package metadata
         uses: actions/cache@v2

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare apt sources
         run: |
@@ -49,13 +49,13 @@ jobs:
           date +date=1-%Y-%m >> $GITHUB_OUTPUT
 
       - name: Cache Haskell package metadata
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.stack/pantry
           key: stack-pantry-${{ runner.os }}-${{ steps.cache-date.outputs.date }}
 
       - name: Cache Haskell dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.stack/*

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -12,16 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - resolver: lts-12
-            ghc: 8.4.4
-          - resolver: lts-14
-            ghc: 8.6.5
-          - resolver: lts-16
-            ghc: 8.8.4
-          - resolver: lts-18
-            ghc: 8.10.7
-          - resolver: lts-19
-            ghc: 9.0.2
+          - resolver: lts-12  # GHC 8.4
+          - resolver: lts-14  # GHC 8.6
+          - resolver: lts-16  # GHC 8.8
+          - resolver: lts-18  # GHC 8.10
+          - resolver: lts-19  # GHC 9.0
 
     steps:
       - name: Clone project
@@ -43,14 +38,6 @@ jobs:
             libxrandr-dev \
             libxss-dev \
             #
-
-      - name: Install GHC
-        # use system ghc (if available) in stack, don't waste GH Actions cache space
-        continue-on-error: true
-        run: |
-          set -ex
-          sudo apt install -y ghc-${{ matrix.ghc }}
-          echo /opt/ghc/${{ matrix.ghc }}/bin >> $GITHUB_PATH
 
       - name: Refresh caches once a month
         id: cache-date

--- a/X11-xft.cabal
+++ b/X11-xft.cabal
@@ -12,7 +12,7 @@ description:   A Haskell bindings to the X Font library. With it, Haskell X11
                fonts with anti-aliasing and subpixel rendering. The bindings
                also provide minimal bindings to Xrender parts.
 build-type:    Simple
-tested-with:   GHC == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.2
+tested-with:   GHC == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.4 || == 9.4.2
 extra-source-files: CHANGES.md
                     README.md
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -12,3 +12,6 @@ github-patches:
 raw-project
   package X11-xft
     flags: +pedantic
+
+-- avoid --haddock-all which overwrites *-docs.tar.gz with tests docs
+haddock-components: libs


### PR DESCRIPTION
# Description

* bump haskell-ci (just housekeeping)
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ related changes
* drop usage of HVR's unmaintained apt repo
* test with GHC 9.4
