### PR TITLE
ci: Regenerate haskell-ci (add GHC 9.10)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240420
+# version: 0.19.20240513
 #
-# REGENDATA ("0.19.20240420",["github","cabal.project"])
+# REGENDATA ("0.19.20240513",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -35,6 +35,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.2
             compilerKind: ghc
             compilerVersion: 9.8.2
@@ -100,7 +105,6 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           apt-get update

--- a/X11-xft.cabal
+++ b/X11-xft.cabal
@@ -12,7 +12,7 @@ description:   A Haskell bindings to the X Font library. With it, Haskell X11
                fonts with anti-aliasing and subpixel rendering. The bindings
                also provide minimal bindings to Xrender parts.
 build-type:    Simple
-tested-with:   GHC == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.5 || == 9.8.2
+tested-with:   GHC == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.8 || == 9.4.8 || == 9.6.5 || == 9.8.2 || == 9.10.1
 extra-source-files: CHANGES.md
                     README.md
 


### PR DESCRIPTION
(automatic PR by https://github.com/liskin/xmonad-maintenance)