### PR TITLE
check for font open errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log / Release Notes
 
+## _unreleased_
+
+  * `xftOpenFont` and `xftOpenFontXlfd` now throw exceptions if opening a
+    font fails. (They used to return a null pointer, usually leading to
+    crashes.)
+
 ## 0.3.4 (2021-12-11)
 
   * Dropped support for GHC 7.10.

--- a/Graphics/X11/Xft.hsc
+++ b/Graphics/X11/Xft.hsc
@@ -73,7 +73,7 @@ import Foreign.C.Types
 -- I wonder how many times this has been reinvented...
 -- (upstream won't accept it because of the GHCisms, I suspect)
 throwIfNullXft :: Coercible a (Ptr b) => String -> IO a -> IO a
-throwIfNullXft fn op = fmap coerce $ throwIfNull fn (fmap coerce op)
+throwIfNullXft fn op = coerce $ throwIfNull fn (coerce op)
 
 -----------------------
 -- Color Handling    --

--- a/Graphics/X11/Xft.hsc
+++ b/Graphics/X11/Xft.hsc
@@ -1,5 +1,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 -----------------------------------------------------------------------------
 -- Module      :  Graphics.X11.Xft
@@ -59,7 +58,7 @@ import Codec.Binary.UTF8.String as UTF8
 import Control.Arrow ((&&&))
 import Control.Monad (void)
 import Data.Char (ord)
-import Data.Coerce (coerce, Coercible)
+import Data.Coerce (coerce)
 import Data.Function (on)
 import Data.List (foldl')
 import Data.List.NonEmpty (NonEmpty)
@@ -69,11 +68,6 @@ import Foreign.C.String
 import Foreign.C.Types
 
 #include <X11/Xft/Xft.h>
-
--- I wonder how many times this has been reinvented...
--- (upstream won't accept it because of the GHCisms, I suspect)
-throwIfNullXft :: Coercible a (Ptr b) => String -> IO a -> IO a
-throwIfNullXft fn op = coerce $ throwIfNull fn (coerce op)
 
 -----------------------
 -- Color Handling    --
@@ -178,15 +172,15 @@ foreign import ccall "XftFontOpenName"
 
 xftFontOpen :: Display -> Screen -> String -> IO XftFont
 xftFontOpen dpy screen fontname =
-    withCAString fontname $
-      \cfontname -> throwIfNullXft "xftFontOpen" $ cXftFontOpen dpy (fi (screenNumberOfScreen screen)) cfontname
+    withCAString fontname $ \cfontname -> coerce (throwIfNull "xftFontOpen") $
+      cXftFontOpen dpy (fi (screenNumberOfScreen screen)) cfontname
 
 foreign import ccall "XftFontOpenXlfd"
   cXftFontOpenXlfd :: Display -> CInt -> CString -> IO XftFont
 
 xftFontOpenXlfd :: Display -> Screen -> String -> IO XftFont
 xftFontOpenXlfd dpy screen fontname =
-    withCAString fontname $ \cfontname -> throwIfNullXft "xftFontOpenXlfd" $
+    withCAString fontname $ \cfontname -> coerce (throwIfNull "xftFontOpenXlfd") $
       cXftFontOpenXlfd dpy (fi (screenNumberOfScreen screen)) cfontname
 
 foreign import ccall "XftLockFace"

--- a/X11-xft.cabal
+++ b/X11-xft.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.24
 name:          X11-xft
-version:       0.3.4
+version:       0.3.5
 license:       BSD3
 license-file:  LICENSE
 author:        Clemens Fruhwirth


### PR DESCRIPTION
This may not have been done because `throwIfNull` can't be used directly. A wrapper using `coerce` works, though. Prevents xmonad from dumping core in `XMonad.Prompt.printPrompt` if an invalid font is specified.